### PR TITLE
Add support for compiling KTG on Mac OS X.

### DIFF
--- a/ktg/Makefile
+++ b/ktg/Makefile
@@ -1,0 +1,2 @@
+demo: gentexture.cpp demo.cpp
+	g++ gentexture.cpp demo.cpp -o demo

--- a/ktg/demo.cpp
+++ b/ktg/demo.cpp
@@ -8,8 +8,26 @@
 #include <stdio.h>
 #include "gentexture.hpp"
 
-#pragma comment(lib,"winmm.lib")
-#include <windows.h>
+#ifdef _WIN32
+  #pragma comment(lib,"winmm.lib")
+  #include <windows.h>
+#else
+  #include <sys/time.h>
+  static long timeGetTime()
+  {
+      timeval tim;
+      gettimeofday(&tim, NULL);
+      return tim.tv_sec * 1000000 + tim.tv_usec / 10;
+  }
+  static int timeBeginPeriod(unsigned int period)
+  {
+      return 0;
+  }
+  static int timeEndPeriod(unsigned int period)
+  {
+      return 0;
+  }
+#endif
 
 // 4x4 matrix multiply
 static void MatMult(Matrix44 &dest,const Matrix44 &a,const Matrix44 &b)


### PR DESCRIPTION
I've added a Makefile so KTG compiles on Mac OS X.

I had to write replacements for the Windows timing functions. I now use gettimeofday to get the most accurate time representation on the target platform.

Typing "make" in the ktg directory creates a "demo" executable that also works on Mac.
