### PR TITLE
fix double allocation in ktg/gentexture.cpp (Issue #4 on upstream)

### DIFF
--- a/ktg/gentexture.cpp
+++ b/ktg/gentexture.cpp
@@ -586,7 +586,7 @@ void GenTexture::Cells(const GenTexture &grad,const CellCenter *centers,sInt nCe
   sVERIFY(((mode & 1) == 0) ? nCenters >= 1 : nCenters >= 2);
 
   Pixel *out = Data;
-  CellPoint *points = new CellPoint[nCenters];
+  CellPoint *points = NULL;
 
   points = new CellPoint[nCenters];
 


### PR DESCRIPTION
Short fix for the memory leak in ktg/gentexture.cpp, closes Issue #4
