### PR TITLE
add CMake build rules for OpenKTG

### DIFF
--- a/ktg/CMakeLists.txt
+++ b/ktg/CMakeLists.txt
@@ -1,0 +1,21 @@
+#
+# OpenKTG CMake build rules
+#
+project(OpenKTG)
+
+cmake_minimum_required(VERSION 2.8)
+
+#
+# libOpenKTG: texture generator library
+set(openKTG_SOURCES gentexture.cpp)
+set(openKTG_HEADERS gentexture.hpp types.hpp)
+
+add_library(OpenKTG ${openKTG_SOURCES})
+
+install(TARGETS OpenKTG ARCHIVE DESTINATION lib)
+install(FILES ${openKTG_HEADERS} DESTINATION include/OpenKTG)
+
+#
+# demo executable
+add_executable(demo demo.cpp)
+target_link_libraries(demo OpenKTG)


### PR DESCRIPTION
This commit adds CMake build rules that build the OpenKTG code as a library.
CMake (http://www.cmake.org/) can be used to generate Make files for a whole lot of operating systems and replaces platform-specific Makefiles, Visual Studio solutions, etc.
