### PR TITLE
Add a shell parameter to load an external wire.txt

### DIFF
--- a/altona_wz4/altona/main/wz4lib/gui.cpp
+++ b/altona_wz4/altona/main/wz4lib/gui.cpp
@@ -283,7 +283,13 @@ void MainWindow::MainInit()
 
   ExtendWireRegister();
 
-  sWire->ProcessText(WireTXT,L"werkkzeug4.wire.txt");
+  // if -w shell parameter is set, load external wire.txt else load internal default wire.txt
+  const sChar *wirefilename = sGetShellParameter(L"w",0);
+  if(wirefilename && sCreateFile(wirefilename,sFA_READ) )
+    sWire->ProcessFile(wirefilename);
+  else
+    sWire->ProcessText(WireTXT,L"werkkzeug4.wire.txt");
+
   ExtendWireProcess();
   sWire->ProcessEnd();
 


### PR DESCRIPTION
To add possibility to change shortcuts and labels menu (translations, keyboard layout or preferences)

Just need to export and edit "werkkzeug4.wire.txt" and if -w shell parameter is set, load external wire.txt else load internal default wire.txt

exemple : werkkeug4.exe -w azertywire.txt
