### PR TITLE
Extrude op - flag to keep original selected faces

### DIFF
--- a/altona_wz4/wz4/wz4frlib/wz4_mesh.cpp
+++ b/altona_wz4/wz4/wz4frlib/wz4_mesh.cpp
@@ -2679,7 +2679,7 @@ struct Island
   sVector30 Normal;
 };
 
-void Wz4Mesh::Extrude(sInt steps,sF32 amount,sInt flags,const sVector31 &center,sF32 localScale)
+void Wz4Mesh::Extrude(sInt steps,sF32 amount,sInt flags,const sVector31 &center,sF32 localScale,sInt SelectUpdateFlag)
 {
   sVERIFY(steps>0);
 
@@ -2698,6 +2698,10 @@ void Wz4Mesh::Extrude(sInt steps,sF32 amount,sInt flags,const sVector31 &center,
   for(sInt i=0;i<Vertices.GetCount();i++)
     if(map[i]==-1)
       map[i] = i;
+
+  // store original faces (to keep trace of selected faces)
+  sArray<Wz4MeshFace> originalFaces;
+  originalFaces.Add(Faces);
 
   // find connected islands of selected faces
   sInt nFaces = Faces.GetCount();
@@ -3036,10 +3040,24 @@ void Wz4Mesh::Extrude(sInt steps,sF32 amount,sInt flags,const sVector31 &center,
 
   // update selection
 
+  // clear selected vertices
   sFORALL(Vertices,v)
     v->Select = 0.0f;
-  sFORALL(Faces,f)
-    f->Select = (_i>=originalfacecount)?1.0f:0.0f;
+
+  // which faces to select ?
+  switch (SelectUpdateFlag)
+  {
+  case 0: // newest faces
+    sFORALL(Faces,f)
+      f->Select = (_i>=originalfacecount)?1.0f:0.0f;
+    break;
+
+  case 1: // original selected faces
+    sFORALL(originalFaces,f)
+      Faces[_i].Select = (f->Select > 0.0f)?1.0f:0.0f;
+    break;
+  }
+
 
   // done and free all
 

--- a/altona_wz4/wz4/wz4frlib/wz4_mesh.hpp
+++ b/altona_wz4/wz4/wz4frlib/wz4_mesh.hpp
@@ -218,7 +218,7 @@ public:
   void Crease();                  // create a crease between selected and unselected faces
   void Uncrease(sInt select);     // remove all creases at the selected vertices
   void Subdivide(sF32 smooth); // subdivide all selected faces
-  void Extrude(sInt steps,sF32 amount,sInt flags,const sVector31 &center,sF32 localScale);
+  void Extrude(sInt steps,sF32 amount,sInt flags,const sVector31 &center,sF32 localScale,sInt SelectUpdateFlag);
   void Splitter(Wz4Mesh *in,sF32 depth,sF32 scale);
   void Dual(Wz4Mesh *in,sF32 random);
   sBool DivideInChunks(sInt flags,const sVector30 &normal,const sVector30 &rot);

--- a/altona_wz4/wz4/wz4frlib/wz4_mesh_ops.ops
+++ b/altona_wz4/wz4/wz4frlib/wz4_mesh_ops.ops
@@ -1349,10 +1349,11 @@ operator Wz4Mesh Extrude(Wz4Mesh)
     if((Flags & 6)==4)
       float31 Center(-1024..1024);
     float LocalScale(0..16.0 step 0.01) = 1.0;
+	flags SelectUpdateFlag "Selection"("newest faces|original faces");
   }
   code
   {
-    out->Extrude(para->Steps,para->Amount,para->Flags,para->Center,para->LocalScale);
+    out->Extrude(para->Steps,para->Amount,para->Flags,para->Center,para->LocalScale,para->SelectUpdateFlag);
   }
 }
 


### PR DESCRIPTION
issue #32 fixed

Add a flag to keep original selected faces or by default newest faces after etrusion. (doesn't break backwards compatibility, but "keep original selected faces" should be used by default)
