### PR TITLE
select slot : fix channel bug and clear unstored vertex/face when loading slot

### DIFF
--- a/altona_wz4/wz4/wz4frlib/wz4_mesh.cpp
+++ b/altona_wz4/wz4/wz4frlib/wz4_mesh.cpp
@@ -2686,6 +2686,10 @@ void Wz4Mesh::SelStoreLoad(sInt mode, sInt type, sInt slot)
     switch(type)
     {
     case wMST_VERTEX:
+      // clear vertices selection
+      sFORALL(Vertices,v)
+        v->Select = 0.0f;
+
       // read all vertices stored and set selection
       for(int i=0; i<SelVertices[slot].GetCount(); i++)
         Vertices[SelVertices[slot][i].Id].Select = SelVertices[slot][i].Selected;
@@ -2700,6 +2704,8 @@ void Wz4Mesh::SelStoreLoad(sInt mode, sInt type, sInt slot)
       {
         if((f->Selected & (1 << slot)) > 0)
           f->Select = 1;
+        else
+          f->Select = 0;
       }
 
       // clear vertices selection

--- a/altona_wz4/wz4/wz4frlib/wz4_mesh_ops.ops
+++ b/altona_wz4/wz4/wz4frlib/wz4_mesh_ops.ops
@@ -1653,7 +1653,11 @@ operator Wz4Mesh Select(Wz4Mesh,?GenBitmap)
     }
 
     // face or vertex ?
-    sInt type = ((para->Flags&48)==0)?wMST_VERTEX:wMST_FACE;
+    sInt type = 0;
+    if(((para->Flags&0x1c0)!=0x1c0))
+      type = (selectVerts)?wMST_VERTEX:wMST_FACE;
+    if(((para->Flags&0x1c0)==0x1c0))
+      type = ((para->Flags >> 4) & 1)?wMST_FACE:wMST_VERTEX;
 
     // load slot
     if(((para->Flags&0x1c0)==0x1c0))


### PR DESCRIPTION
A flag bug with channel slots in select gui
And forgot to clear unstored vertex/faces when loading a slot.
