### PR TITLE
Add Material for Ribbons & Ribbons2

### DIFF
--- a/altona_wz4/wz4/wz4frlib/chaosfx.cpp
+++ b/altona_wz4/wz4/wz4frlib/chaosfx.cpp
@@ -270,11 +270,11 @@ void RNRibbons::Prepare(Wz4RenderContext *ctx)
 
       p += mat.k * Para.Forward;
       vp->Init(p-mat.i*Para.Side,mat.j,0,sF32(i)/max);
-      vp->u0 =  sF32(0);
+      vp->u0 =  0.0f;
       vp->v0 =  i+(1/Para.Steps);
       vp++;
       vp->Init(p+mat.i*Para.Side,mat.j,1,sF32(i)/max);
-      vp->u0 =  1;
+      vp->u0 =  1.0f;
       vp->v0 =  i+(1/Para.Steps);
       vp++;
     }
@@ -346,6 +346,7 @@ RNRibbons2::RNRibbons2()
   Mtrl = new sSimpleMaterial;
   Mtrl->Flags = sMTRL_CULLOFF|sMTRL_ZON|sMTRL_LIGHTING;
   Mtrl->Prepare(sVertexFormatStandard);
+  MtrlEx = 0;
 
   Anim.Init(Wz4RenderType->Script);
 }
@@ -354,6 +355,7 @@ RNRibbons2::~RNRibbons2()
 {
   delete Geo;
   delete Mtrl;
+  MtrlEx->Release();
 }
 
 /****************************************************************************/
@@ -376,6 +378,8 @@ void RNRibbons2::Prepare(Wz4RenderContext *ctx)
   sVector30 camdir,norm;
   sVector30 dir,d0,d1;
   sVector31 p0,p1,p2,p3;
+
+  if(MtrlEx) MtrlEx->BeforeFrame(0);
 
   Random.Seed(1);
 
@@ -431,7 +435,11 @@ void RNRibbons2::Prepare(Wz4RenderContext *ctx)
       norm.Unit();
 
       vp[0].Init(pos-d0,norm,0,0);
+      vp[0].u0 = 0.0f;
+      vp[0].v0 = j+(1/Para.Length);
       vp[1].Init(pos+d0,norm,1,0);
+      vp[1].u0 = 1.0f;
+      vp[1].v0 = j+(1/Para.Length);
       vp+=2;
     }
   }
@@ -455,15 +463,23 @@ void RNRibbons2::Prepare(Wz4RenderContext *ctx)
 
 void RNRibbons2::Render(Wz4RenderContext *ctx)
 {
+  sMaterialEnv env;
+
   if(ctx->IsCommonRendermode())
   {
-    sMaterialEnv env;
-    env.AmbientColor = 0xff404040;
-    env.LightColor[0] = 0xffc0c0c0;
-    env.LightColor[1] = 0xffc0c0c0;
-    env.LightDir[0].Init(0,1,0);
-    env.LightDir[1].Init(0,-1,0);
-    env.Fix();
+    if(!MtrlEx)
+    {
+      env.AmbientColor = 0xff404040;
+      env.LightColor[0] = 0xffc0c0c0;
+      env.LightColor[1] = 0xffc0c0c0;
+      env.LightDir[0].Init(0,1,0);
+      env.LightDir[1].Init(0,-1,0);
+      env.Fix();
+    }
+    else
+    {
+      if(MtrlEx->SkipPhase(ctx->RenderMode,Para.LightEnv)) return;
+    }
 
     sMatrix34CM *mat;
     sFORALL(Matrices,mat)
@@ -471,10 +487,15 @@ void RNRibbons2::Render(Wz4RenderContext *ctx)
       sViewport view = ctx->View;
       view.UpdateModelMatrix(sMatrix34(*mat));
 
-      sCBuffer<sSimpleMaterialEnvPara> cb;
-      cb.Data->Set(view,env);
+      if(!MtrlEx)
+      {
+        sCBuffer<sSimpleMaterialEnvPara> cb;
+        cb.Data->Set(view,env);
+        Mtrl->Set(&cb);
+      }
+      else
+        MtrlEx->Set(ctx->RenderMode|sRF_MATRIX_ONE,Para.LightEnv,mat,0,0,0);
 
-      Mtrl->Set(&cb);
       Geo->Draw();
     }
   }

--- a/altona_wz4/wz4/wz4frlib/chaosfx.hpp
+++ b/altona_wz4/wz4/wz4frlib/chaosfx.hpp
@@ -101,6 +101,8 @@ public:
   void Render(Wz4RenderContext *ctx);
 
   void Eval(const sVector31 &pos,sVector30 &norm);
+
+  Wz4Mtrl *MtrlEx;
 };
 
 /****************************************************************************/

--- a/altona_wz4/wz4/wz4frlib/chaosfx_ops.ops
+++ b/altona_wz4/wz4/wz4frlib/chaosfx_ops.ops
@@ -118,7 +118,7 @@ operator Wz4Render Ribbons(?Wz4Mtrl)
 
 /****************************************************************************/
 
-operator Wz4Render Ribbons2()
+operator Wz4Render Ribbons2(?Wz4Mtrl)
 {
   column = 1;
   parameter
@@ -130,6 +130,7 @@ operator Wz4Render Ribbons2()
     float30 Spread(-16..16 step 0.1) = 1;
     anim float Forward (0..4 step 0.001) = 0.1;
     anim float Side (0..4 step 0.001) = 0.05;
+    int LightEnv(0..15)=0;
     group "Sources";
     float31 Source0(-16..16 step 0.01);
     nolabel float Power0(-16..16 step 0.001);
@@ -146,8 +147,21 @@ operator Wz4Render Ribbons2()
   {
     RNRibbons2 *node = new RNRibbons2();
     node->ParaBase = node->Para = *para;
+
+    if(in0)
+    {
+      node->MtrlEx = in0;
+      in0->AddRef();
+    }
+
+
     out->RootNode = node;
-    out->AddChilds(cmd,para->Renderpass);
+
+    if(in0)
+      out->AddCode(cmd,para->Renderpass);
+    else
+      out->AddChilds(cmd,para->Renderpass);
+    //out->AddChilds(cmd,para->Renderpass);
   }
   handles
   {


### PR DESCRIPTION
This commit add material for Ribbons and Ribbons2 operators.

I didn't found any flag to disable BackFace culling with this material, so by default with a material input, only front faces are visibles, it is not very annoying because this could be fixed by enabling "doublesided" option in material operator but, maybe there is a way to disable culling ?

Thanks
