### PR TITLE
SplitEdgeAlongPlane bug

### DIFF
--- a/altona_wz4/wz4/wz4frlib/wz4_mesh.cpp
+++ b/altona_wz4/wz4/wz4frlib/wz4_mesh.cpp
@@ -6414,8 +6414,8 @@ static sInt ClassifyVertex(const Wz4MeshVertex &v,const sVector4 &plane)
 sInt Wz4Mesh::SplitEdgeAlongPlane(sInt va,sInt vb,const sVector4 &plane)
 {
   // TODO: hash table so vertices aren't generated multiple times
-  const Wz4MeshVertex &a = Vertices[va];
-  const Wz4MeshVertex &b = Vertices[vb];
+  const Wz4MeshVertex a = Vertices[va];
+  const Wz4MeshVertex b = Vertices[vb];
 
   sF32 da = a.Pos ^ plane;
   sF32 db = b.Pos ^ plane;


### PR DESCRIPTION
First call to Wz4Mesh::SplitEdgeAlongPlane create a vertex with a wrong position so mesh could be broken or wz randomly crash

when : 

  Wz4MeshVertex *v = Vertices.AddMany(1); <== change content of a and b
  v->Pos.Fade(t,a.Pos,b.Pos);

a and b become invalid, because they are references variables, just replacing with a non references variable, fix the bug. Another solution is to replace *v by a non pointer variable and add v to array at end of procedure AddTail(v) - like in ChaosFXMesh::SplitEdgeAlongPlane
