### PR TITLE
Wz4: new operator FromVertex, generate particles nodes from vertices mesh

### DIFF
--- a/altona_wz4/wz4/wz4frlib/fxparticle.cpp
+++ b/altona_wz4/wz4/wz4frlib/fxparticle.cpp
@@ -3344,3 +3344,61 @@ void RPFromMesh::Func(Wz4PartInfo &pinfo,sF32 time,sF32 dt)
 }
 
 /****************************************************************************/
+/***                                                                      ***/
+/***   FromVertex (generate node particles from each vertex in the mesh)  ***/
+/***                                                                      ***/
+/****************************************************************************/
+
+RPFromVertex::RPFromVertex()
+{
+}
+
+RPFromVertex::~RPFromVertex()
+{
+}
+
+void RPFromVertex::Init(Wz4Mesh *mesh)
+{
+  Wz4MeshVertex * vp;
+  Para = ParaBase;
+  sRandom rnd;
+  rnd.Seed(Para.RandomSeed);
+
+  sVERIFY(mesh != 0);
+
+  sFORALL(mesh->Vertices, vp)
+  {
+    if (rnd.Float(1)<=Para.Random)
+    {
+      Part *p = Parts.AddMany(1);
+      p->Pos.Init(vp->Pos.x, vp->Pos.y, vp->Pos.z);
+    }
+  }
+}
+
+
+void RPFromVertex::Simulate(Wz4RenderContext *ctx)
+{
+  //SimulateCalc(ctx);
+}
+
+sInt RPFromVertex::GetPartCount()
+{
+  return Parts.GetCount();
+}
+
+sInt RPFromVertex::GetPartFlags()
+{
+  return 0;
+}
+
+void RPFromVertex::Func(Wz4PartInfo &pinfo,sF32 time,sF32 dt)
+{
+  sInt count = Parts.GetCount();
+
+  for(sInt i=0;i<count;i++)
+  {
+    pinfo.Parts[i].Init(Parts[i].Pos,1.0f);
+  }
+  pinfo.Used = count;
+}

--- a/altona_wz4/wz4/wz4frlib/fxparticle.hpp
+++ b/altona_wz4/wz4/wz4frlib/fxparticle.hpp
@@ -574,6 +574,31 @@ public:
   void Func(Wz4PartInfo &pinfo,sF32 time,sF32 dt);
 };
 
+
+/****************************************************************************/
+
+class RPFromVertex : public Wz4ParticleNode
+{
+  struct Part
+  {
+    sVector31 Pos;
+  };
+  sArray<Part> Parts;
+public:
+  RPFromVertex();
+  ~RPFromVertex();
+  void Init(Wz4Mesh *mesh);
+
+  Wz4ParticlesParaFromVertex Para,ParaBase;
+  Wz4ParticlesParaFromVertex Anim;
+  Wz4ParticleNode *Source;
+
+  void Simulate(Wz4RenderContext *ctx);
+  sInt GetPartCount();
+  sInt GetPartFlags();
+  void Func(Wz4PartInfo &pinfo,sF32 time,sF32 dt);
+};
+
 /****************************************************************************/
 
 class RPFromMesh : public Wz4ParticleNode

--- a/altona_wz4/wz4/wz4frlib/fxparticle_ops.ops
+++ b/altona_wz4/wz4/wz4frlib/fxparticle_ops.ops
@@ -223,6 +223,27 @@ operator Wz4Particles Cloud2()
 
 /****************************************************************************/
 
+operator Wz4Particles FromVertex(Wz4Mesh)
+{
+  tab = Wz4Render;
+  column = 3;
+  parameter
+  {
+    float Random(0..1 step 0.01) = 1;
+    int RandomSeed(0..255);
+  }
+  code
+  {
+    RPFromVertex *node = new RPFromVertex();
+    node->ParaBase = node->Para = *para;
+    node->Init(in0);
+    out->RootNode = node;
+    out->AddCode(cmd);
+  }
+}
+
+/****************************************************************************/
+
 operator Wz4Particles Wobble(Wz4Particles)
 {
   tab = Wz4Render;


### PR DESCRIPTION
FromVertex a new operator similar to FromMesh, to generate particles nodes from a mesh.
The difference is that is based on the vertices intead of the bounding box of the mesh.
